### PR TITLE
Use PrivateAssets for all coming from Aksio.Defaults

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aksio.Defaults" Version="1.*"/>
+        <PackageReference Include="Aksio.Defaults" Version="1.*" PrivateAssets="All"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Adding `PrivateAssets="All"` for the **Aksio.Defaults** package reference to avoid it bleeding its rules to consumers.
