### PR TITLE
Equality-extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,40 +73,6 @@ dotnet_naming_symbols.public_symbols.applicable_kinds = property,method,field,ev
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers = readonly
 
-## Specific rule suppression
-# CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = none
-# CA2016: Forward the CancellationToken parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = none
-# CA1716: Identifiers should not match keywords
-dotnet_diagnostic.CA1716.severity = none
-# CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1725.severity = none
-# CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1710.severity = none
-#CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1711.severity = none
-# Add missing cases to switch expression (IDE0072 and IDE0010)
-# a bug in roslyn: https://github.com/dotnet/roslyn/issues/48876
-dotnet_diagnostic.IDE0072.severity = none
-dotnet_diagnostic.IDE0010.severity = none
-# IDE0130: Namespace does not match folder structure
-dotnet_diagnostic.IDE0130.severity = none
-# CA1834: Use StringBuilder.Append(char) for single character strings
-dotnet_diagnostic.CA1834.severity = none
-# CA1805: Do not initialize unnecessarily.
-dotnet_diagnostic.CA1805.severity = none
-# Use pattern matching (not operator) (IDE0083)
-dotnet_diagnostic.IDE0083.severity = none
-# CA1309: Use ordinal StringComparison
-dotnet_diagnostic.CA1309.severity = none
-# CA1000: Do not declare static members on generic types
-dotnet_diagnostic.CA1000.severity = none
-# RCS1018: Add accessibility modifiers
-dotnet_diagnostic.RCS1018.severity = none
-# RCS1194: Implement exception constructors
-dotnet_diagnostic.RCS1194.severity = none
-
 #### C# Coding Conventions ####
 
 # var preferences
@@ -137,14 +103,10 @@ csharp_style_unused_value_expression_statement_preference = false:none
 
 # not ready for changing everything to pattern matching
 csharp_style_prefer_pattern_matching = false:none
-
 csharp_using_directive_placement = outside_namespace:error
-
-
 csharp_style_prefer_range_operator = false:none
 
 # CSharp formatting rules:
 # dont want these bombing the build logs, will still show up in the IDE
-dotnet_diagnostic.IDE0055.severity = none
 # prefere brace indentation when creating objects etc
 csharp_indent_braces = false

--- a/Source/ShouldCollectionExtensions.cs
+++ b/Source/ShouldCollectionExtensions.cs
@@ -159,6 +159,20 @@ namespace Aksio.Specifications
         }
 
         /// <summary>
+        /// Assert that all items in a collection are conforming based on the decision of a callback.
+        /// </summary>
+        /// <param name="collection">Collection to assert.</param>
+        /// <param name="expected">Callback that will check conformity.</param>
+        /// <typeparam name="T">Type of element.</typeparam>
+        public static void ShouldEachConformTo<T>(this IEnumerable<T> collection, Func<T, bool> expected)
+        {
+            foreach (var item in collection)
+            {
+                item.ShouldMatch(expected);
+            }
+        }
+
+        /// <summary>
         /// Assert that a collection does not contain a specific element.
         /// </summary>
         /// <param name="collection">Collection to assert.</param>

--- a/Source/ShouldEqualityExtensions.cs
+++ b/Source/ShouldEqualityExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Aksio.Specifications
@@ -94,6 +95,17 @@ namespace Aksio.Specifications
         public static void ShouldNotBeSimilar<T>(this T actual, T expected)
         {
             Assert.NotStrictEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Assert that an object matches - based on a callback making the decision.
+        /// </summary>
+        /// <param name="actual">Actual value.</param>
+        /// <param name="expected">Callback deciding what is expected.</param>
+        /// <typeparam name="T">Type of object.</typeparam>
+        public static void ShouldMatch<T>(this T actual, Func<T, bool> expected)
+        {
+            Assert.True(expected(actual));
         }
     }
 }


### PR DESCRIPTION
### Added

- Should extension method for collections: `.ShouldEachConformTo<>()` - taking a callback for checking conformity.
- Should extension method for checking if an object matches: `.ShouldMatch<>()` - taking a callback that decides what it is expecting.

