### PR TITLE
Async-catch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,10 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591;RCS1090;CA2252;CS8632;RCS1217;SA1633</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;RCS1090;CA2252;CS8632;RCS1217;SA1633;CA2007</NoWarn>
         <Nullable>disable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
 
     <!-- Package versions -->

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -5,7 +5,7 @@
         <IsTestProject>true</IsTestProject>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>disable</Nullable>
-        <NoWarn>CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134</NoWarn>
+        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sample/SecurityService.cs
+++ b/Sample/SecurityService.cs
@@ -11,5 +11,15 @@ namespace Sample
                 SessionId = Guid.NewGuid().ToString()
             };
         }
+
+        public Task<UserToken> AuthenticateAsync(string username, string password)
+        {
+            if (username == null || password == null) throw new UserMustBeSpecified();
+            return Task.FromResult(new UserToken
+            {
+                Role = Roles.Admin,
+                SessionId = Guid.NewGuid().ToString()
+            });
+        }
     }
 }

--- a/Sample/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
+++ b/Sample/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
@@ -1,0 +1,20 @@
+using Aksio.Specifications;
+using Xunit;
+
+namespace Sample.for_SecurityServiceAsync
+{
+    public class When_authenticating_a_null_user_async : given.no_user_authenticated
+    {
+        Exception result;
+
+        Task Establish()
+        {
+            Console.WriteLine("Establish in specification");
+            return Task.Delay(50);
+        }
+
+        async Task Because() => result = await Catch.ExceptionAsync(() => subject.AuthenticateAsync(null, null));
+
+        [Fact] void should_throw_user_must_be_specified_exception() => result.ShouldBeOfExactType<UserMustBeSpecified>();
+    }
+}

--- a/Source/Catch.cs
+++ b/Source/Catch.cs
@@ -1,5 +1,3 @@
-using System;
-
 #nullable disable
 
 namespace Aksio.Specifications
@@ -42,6 +40,25 @@ namespace Aksio.Specifications
                 callback();
             }
             catch (T ex)
+            {
+                return ex;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Catch a specific exception that occurs from the wrapped async callback.
+        /// </summary>
+        /// <param name="callback">Async callback to wrap.</param>
+        /// <returns>Exception that happened - if any. Null if not.</returns>
+        public static async Task<Exception> ExceptionAsync(Func<Task> callback)
+        {
+            try
+            {
+                await callback();
+            }
+            catch (Exception ex)
             {
                 return ex;
             }

--- a/Source/ShouldCollectionExtensions.cs
+++ b/Source/ShouldCollectionExtensions.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/ShouldComparableExtensions.cs
+++ b/Source/ShouldComparableExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/ShouldEqualityExtensions.cs
+++ b/Source/ShouldEqualityExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/ShouldStringExtensions.cs
+++ b/Source/ShouldStringExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/ShouldTypeExtensions.cs
+++ b/Source/ShouldTypeExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/Specification.cs
+++ b/Source/Specification.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Aksio.Specifications

--- a/Source/SpecificationMethods.cs
+++ b/Source/SpecificationMethods.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace Aksio.Specifications
 {

--- a/Source/Specifications.csproj
+++ b/Source/Specifications.csproj
@@ -3,9 +3,8 @@
         <AssemblyName>Aksio.Specifications</AssemblyName>
         <RootNamespace>Aksio.Specifications</RootNamespace>
         <IsPackable>true</IsPackable>
-        <NoWarn>RCS1090</NoWarn>
+        <NoWarn>$(NoWarn);RCS1090</NoWarn>
         
-
         <RepositoryUrl>https://github.com/aksio-system/Specifications</RepositoryUrl>
         <PackageProjectUrl>https://github.com/aksio-system/Specifications</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "6.0.0",
+      "rollForward": "latestFeature"
+    }
+  }


### PR DESCRIPTION
## Summary

Introducing ability to catch exceptions from async calls in a more elegant way:

```csharp
async Task Because() => result = await Catch.ExceptionAsync(() => subject.AuthenticateAsync(null, null));

[Fact] void should_throw_user_must_be_specified_exception() => result.ShouldBeOfExactType<UserMustBeSpecified>();

```


### Added

- Adding `ExceptionAsync` method on the `Catch` class.
