### PR TITLE
Removing Async postfix for Exception catching

### DIFF
--- a/Sample/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
+++ b/Sample/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
@@ -13,7 +13,7 @@ namespace Sample.for_SecurityServiceAsync
             return Task.Delay(50);
         }
 
-        async Task Because() => result = await Catch.ExceptionAsync(() => subject.AuthenticateAsync(null, null));
+        async Task Because() => result = await Catch.Exception(() => subject.AuthenticateAsync(null, null));
 
         [Fact] void should_throw_user_must_be_specified_exception() => result.ShouldBeOfExactType<UserMustBeSpecified>();
     }

--- a/Source/Catch.cs
+++ b/Source/Catch.cs
@@ -52,7 +52,7 @@ namespace Aksio.Specifications
         /// </summary>
         /// <param name="callback">Async callback to wrap.</param>
         /// <returns>Exception that happened - if any. Null if not.</returns>
-        public static async Task<Exception> ExceptionAsync(Func<Task> callback)
+        public static async Task<Exception> Exception(Func<Task> callback)
         {
             try
             {


### PR DESCRIPTION


## Summary

For consistency, since we don't have **Async** postfixes anywhere in our API; - removing it.

```csharp
async Task Because() => result = await Catch.Exception(() => subject.AuthenticateAsync(null, null));

[Fact] void should_throw_user_must_be_specified_exception() => result.ShouldBeOfExactType<UserMustBeSpecified>();
```

Summary of the PR here. The GitHub release description is created from this comment so keep it nice and descriptive.
Remember to remove sections that you don't need or use.
If it does not make sense to have a summary, you can take that out as well.

### Changed

- Removing **Async** postfix for handling async exceptions - for consistency.